### PR TITLE
Update stylesheet link to use Zalando Tech Radar's raw CSS

### DIFF
--- a/tech_radar/index.html
+++ b/tech_radar/index.html
@@ -9,8 +9,10 @@
 <link rel="shortcut icon" href="favicon.ico">
 
 <script src="https://d3js.org/d3.v4.min.js"></script>
-<script src="https://zalando.github.io/tech-radar/release/radar-0.9.js"></script>
-<link rel="stylesheet" href="https://raw.githubusercontent.com/zalando/tech-radar/master/docs/radar.css">
+
+<script src="https://cdn.jsdelivr.net/gh/zalando/tech-radar@master/docs/release/radar-0.9.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/zalando/tech-radar@696b599/docs/radar.css">
+  
 </head>
 
 <body>

--- a/tech_radar/index.html
+++ b/tech_radar/index.html
@@ -9,8 +9,8 @@
 <link rel="shortcut icon" href="favicon.ico">
 
 <script src="https://d3js.org/d3.v4.min.js"></script>
-<script src="https://cdn.jsdelivr.net/gh/moj-analytical-services/tech-radar@v0.0.4/docs/radar.js"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/moj-analytical-services/tech-radar@master/docs/radar.css">
+<script src="https://zalando.github.io/tech-radar/release/radar-0.9.js"></script>
+<link rel="stylesheet" href="https://raw.githubusercontent.com/zalando/tech-radar/master/docs/radar.css">
 </head>
 
 <body>


### PR DESCRIPTION
we may as well use the **jsDelivr CDN**

```html
<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/zalando/tech-radar@master/docs/radar.css">
```
The Zalando Tech Radar repository does not provide specific releases and relies solely on the master branch. 

Using `@master` in the CDN URL / `raw.githubusercontent` means the page will always fetch the latest version of the CSS. 

This approach can lead to unexpected changes or potential instability if updates are made to the master branch without prior notice.

I am considering using the commit-hash

```html
<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/zalando/tech-radar@696b599/docs/radar.css">
```